### PR TITLE
Remove redundant nil checks

### DIFF
--- a/cloudmock/aws/mockec2/internetgateways.go
+++ b/cloudmock/aws/mockec2/internetgateways.go
@@ -116,11 +116,9 @@ func (m *MockEC2) DescribeInternetGateways(request *ec2.DescribeInternetGateways
 
 			case "attachment.vpc-id":
 				for _, v := range filter.Values {
-					if internetGateway.Attachments != nil {
-						for _, attachment := range internetGateway.Attachments {
-							if *attachment.VpcId == *v {
-								match = true
-							}
+					for _, attachment := range internetGateway.Attachments {
+						if *attachment.VpcId == *v {
+							match = true
 						}
 					}
 				}

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -82,10 +82,8 @@ func validateClusterSpec(spec *kops.ClusterSpec, fieldPath *field.Path) field.Er
 		allErrs = append(allErrs, validateHookSpec(&spec.Hooks[i], fieldPath.Child("hooks").Index(i))...)
 	}
 
-	if spec.FileAssets != nil {
-		for i, x := range spec.FileAssets {
-			allErrs = append(allErrs, validateFileAssetSpec(&x, fieldPath.Child("fileAssets").Index(i))...)
-		}
+	for i, x := range spec.FileAssets {
+		allErrs = append(allErrs, validateFileAssetSpec(&x, fieldPath.Child("fileAssets").Index(i))...)
 	}
 
 	if spec.KubeAPIServer != nil {

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
@@ -115,14 +115,12 @@ func serializeFirewallAllowed(r *compute.FirewallAllowed) string {
 
 func (e *FirewallRule) mapToGCE(project string) (*compute.Firewall, error) {
 	var allowed []*compute.FirewallAllowed
-	if e.Allowed != nil {
-		for _, a := range e.Allowed {
-			p, err := parseFirewallAllowed(a)
-			if err != nil {
-				return nil, err
-			}
-			allowed = append(allowed, p)
+	for _, a := range e.Allowed {
+		p, err := parseFirewallAllowed(a)
+		if err != nil {
+			return nil, err
 		}
+		allowed = append(allowed, p)
 	}
 	firewall := &compute.Firewall{
 		Name:         *e.Name,


### PR DESCRIPTION
These nil checks before the range loop are redundant (see https://staticcheck.io/docs/gosimple#S1031)